### PR TITLE
Ensure consumeCount > 1 before breaking out of range

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -204,7 +204,7 @@ func consume(opts *ConfigOpts, conn *amqp.Connection) {
 
 			count += 1
 
-			if count >= opts.consumeCount {
+			if opts.consumeCount > -1 && count >= opts.consumeCount {
 				consumeCloseChan <- true
 				break
 			}


### PR DESCRIPTION
-1 wasn't being respected for continuous consuming from queue